### PR TITLE
Adds support for an optional array of subjectAltNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Or even override the default attributes:
       public_mode 0644
       private_mode 0600
       bundle_ca true
+      subject_alternate_names nil
     end
 
 This final example will create three files in `/opt/chef_vault_pki`:
@@ -101,6 +102,7 @@ See `attributes/default.rb` for defaults.
 * `node['chef_vault_pki']['private_mode']` - permissions of private files (e.g. keys)
 * `node['chef_vault_pki']['bundle_ca']` - this bundles the ca cert with the client cert
 * `node['chef_vault_pki']['standalone']` - doesn't attempt to read the ca from chef-vault, but generates on instead (e.g. for testing)
+* `node['chef_vault_pki']['subject_alternate_names']` - Optional array of SANs (e.g. ['DNS:foo.example', 'DNS:bar.example', 'IP:127.0.0.1'])
 
 Generated client certs are added to the node attributes:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,4 @@ default['chef_vault_pki']['public_mode'] = 0644
 default['chef_vault_pki']['private_mode'] = 0600
 default['chef_vault_pki']['bundle_ca'] = false
 default['chef_vault_pki']['standalone'] = false
+default['chef_vault_pki']['subject_alternate_names'] = nil

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -201,6 +201,11 @@ action :create do
       extension_factory.create_extension 'keyUsage', 'keyEncipherment,dataEncipherment,digitalSignature'
       extension_factory.create_extension 'subjectKeyIdentifier', 'hash'
 
+      # Add any subjectAltName (SAN)
+      if opt['subject_alternate_names'] && !opt['subject_alternate_names'].empty?
+        extension_factory.create_extension("subjectAltName", opt['subject_alternate_names'].join(','))
+      end
+
       Chef::Log.debug "chef_vault_pki: Signing CSR with CA #{opt['ca']}"
       csr_cert.sign ca_key, OpenSSL::Digest::SHA1.new
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -23,7 +23,7 @@ action :create do
 
   # Attributes for the cert
   opt = { 'name' => new_resource.name.gsub(' ', '_') }
-  %w[ data_bag ca expires expires_factor key_size path path_mode path_recursive owner group ca_owner ca_group public_mode private_mode bundle_ca standalone ].each do |attr|
+  %w[ data_bag ca expires expires_factor key_size path path_mode path_recursive owner group ca_owner ca_group public_mode private_mode bundle_ca standalone subject_alternate_names ].each do |attr|
     opt[attr] = new_resource.send(attr) ? new_resource.send(attr) : node['chef_vault_pki'][attr]
   end
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -21,3 +21,4 @@ attribute :private_mode, :kind_of => [String, Integer]
 attribute :data_bag, :kind_of => String
 attribute :bundle_ca, :kind_of => [TrueClass, FalseClass]
 attribute :standalone, :kind_of => [TrueClass, FalseClass]
+attribute :subject_alternate_names, :kind_of => [NilClass, FalseClass, Array]


### PR DESCRIPTION
# WIP! Don't merge without testing ⚠️ 

## Expected Usage

```ruby
chef_vault_pki "sensu_#{node.name}" do
  subject_alternate_names ['IP:127.0.0.1', 'DNS:other.domain.example']
end
```

## More info

https://en.wikipedia.org/wiki/Subject_Alternative_Name